### PR TITLE
Return reference to app

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,4 +136,6 @@ function onerror(app, options) {
       ? { error: err.message }
       : { error: http.STATUS_CODES[this.status] };
   }
+
+  return app;
 }

--- a/test/fluid.test.js
+++ b/test/fluid.test.js
@@ -1,0 +1,24 @@
+/*!
+ * koa-onerror - test/text.test.js
+ * Copyright(c) 2014 dead_horse <dead_horse@qq.com>
+ * MIT Licensed
+ */
+
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+var koa = require('koa');
+var assert = require('assert');
+var onerror = require('..');
+
+describe('fluid.test.js', function () {
+  it('should return app reference', function () {
+    var app = koa();
+    var res = onerror(app);
+    assert(res instanceof koa);
+    assert(res === app);
+  });
+});


### PR DESCRIPTION
Allows for a more fluid interface, for example:
```
let app = error(koa(), {...});
```