### PR TITLE
Send default text/plain body if message is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ function onerror(app, options) {
     this.res._headers = {};
 
     this.body = isDev || err.expose
-      ? err.message
+      ? err.message || http.STATUS_CODES[this.status]
       : http.STATUS_CODES[this.status];
   }
 

--- a/test/text.test.js
+++ b/test/text.test.js
@@ -42,6 +42,18 @@ describe('text.test.js', function () {
     .expect('this message will be expose', done);
   });
 
+  it('should show default message if undefined', function (done) {
+    var app = koa();
+    app.on('error', function () {});
+    onerror(app);
+    app.use(exposeBlankError);
+
+    request(app.callback())
+    .get('/')
+    .set('Accept', 'text/plain')
+    .expect(500, done);
+  });
+
   it('should stream error ok', function (done) {
     var app = koa();
     app.on('error', function () {});
@@ -76,6 +88,13 @@ describe('text.test.js', function () {
 
 function* exposeError() {
   var err = new Error('this message will be expose');
+  err.expose = true;
+  throw err;
+}
+
+function* exposeBlankError() {
+  var err = new Error();
+  err.message = undefined;
   err.expose = true;
   throw err;
 }


### PR DESCRIPTION
Koa detects undefined response body and automatically sets the status
to 204 if explicit status does not allow an empty body.

See: https://github.com/koajs/koa/blob/master/lib/response.js#L135