### PR TITLE
fix: don't throw when non-error object passed

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const assert = require('assert');
 const http = require('http');
 const path = require('path');
 const copy = require('copy-to');
@@ -35,7 +34,10 @@ function onerror(app, options) {
       return;
     }
 
-    assert(err instanceof Error, 'non-error thrown: ' + err);
+    // wrap non-error object
+    if (!(err instanceof Error)) {
+      err = new Error('non-error thrown: ' + err);
+    }
 
     // delegate
     this.app.emit('error', err, this);

--- a/test/json.test.js
+++ b/test/json.test.js
@@ -56,6 +56,21 @@ describe('json.test.js', function() {
     .expect(500)
     .expect({ message: 'error' }, done);
   });
+
+  it('should wrap non-error object', function(done) {
+    const app = koa();
+    app.on('error', function() {});
+    onerror(app);
+    app.use(function*() {
+      throw 1;
+    });
+
+    request(app.callback())
+    .get('/')
+    .set('Accept', 'application/json')
+    .expect(500)
+    .expect({ error: 'non-error thrown: 1' }, done);
+  });
 });
 
 function* commonError() {


### PR DESCRIPTION
closes #13 