### PR TITLE
Escape unsafe characters in html response

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,6 +118,17 @@ function json(err, ctx) {
   ctx.body = { error: message };
 }
 
+function htmlSafe(str) {
+  if (typeof str !== 'string') {
+    return '';
+  }
+  return str.replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#039;");
+}
+
 /**
  * default html error handler
  * @param {Error} err
@@ -125,7 +136,7 @@ function json(err, ctx) {
 
 function html(err, ctx) {
   ctx.body = defaultTemplate
-    .replace('{{status}}', err.status)
-    .replace('{{stack}}', err.stack);
+    .replace('{{status}}', htmlSafe(err.status))
+    .replace('{{stack}}', htmlSafe(err.stack));
   ctx.type = 'html';
 }

--- a/index.js
+++ b/index.js
@@ -119,14 +119,11 @@ function json(err, ctx) {
 }
 
 function htmlSafe(str) {
-  if (typeof str !== 'string') {
-    return '';
-  }
-  return str.replace(/&/g, "&amp;")
-            .replace(/</g, "&lt;")
-            .replace(/>/g, "&gt;")
-            .replace(/"/g, "&quot;")
-            .replace(/'/g, "&#039;");
+  return String(str).replace(/&/g, "&amp;")
+                    .replace(/</g, "&lt;")
+                    .replace(/>/g, "&gt;")
+                    .replace(/"/g, "&quot;")
+                    .replace(/'/g, "&#039;");
 }
 
 /**

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -43,6 +43,19 @@ describe('html.test.js', function() {
     .expect(/<p>Looks like something broke!<\/p>/)
     .expect(/ENOENT/, done);
   });
+
+  it('should unsafe error ok', function(done) {
+    const app = new koa();
+    app.on('error', function() {});
+    onerror(app);
+    app.use(unsafeError);
+
+    request(app.callback())
+    .get('/')
+    .set('Accept', 'text/html')
+    .expect(/<p>Looks like something broke!<\/p>/)
+    .expect(/&lt;anonymous&gt;/, done);
+  });
 });
 
 function commonError() {
@@ -58,4 +71,8 @@ async function commonSleepError() {
 
 function streamError(ctx) {
   ctx.body = fs.createReadStream('not exist');
+}
+
+function unsafeError() {
+  throw new Error('<anonymous>');
 }


### PR DESCRIPTION
This fixes an html injection vulnerability in the case where error message or status can be influenced by the caller. An example of such an error might be:
```
throw new Error(`Invalid username ${username}`);
```

Incidentally, stack traces can also contain `<` and `>`.