### PR TITLE
feat: reveal all fields of non-error object

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,19 +31,19 @@ module.exports = function onerror(app, options) {
     // to node-style callbacks.
     if (err == null) return;
 
-    // ignore all pedding request stream
+    // ignore all pending request stream
     if (this.req) sendToWormhole(this.req);
 
     // wrap non-error object
     if (!(err instanceof Error)) {
       const newError = new Error('non-error thrown: ' + err);
       // err maybe an object, try to copy the name, message and stack to the new error instance
-      if (err) {
-        if (err.name) newError.name = err.name;
-        if (err.message) newError.message = err.message;
-        if (err.stack) newError.stack = err.stack;
-        if (err.status) newError.status = err.status;
-        if (err.headers) newError.headers = err.headers;
+      if (err && typeof err === 'object') {
+        for (const key in err) {
+          if (err.hasOwnProperty(key)) {
+            newError[key] = err[key];
+          }
+        }
       }
       err = newError;
     }

--- a/test/json.test.js
+++ b/test/json.test.js
@@ -86,6 +86,26 @@ describe('json.test.js', () => {
       .expect({ error: 'non-error thrown: 1' }, done);
   });
 
+  it('should wrap non-error object and reveal all its fields', done => {
+    const app = new koa();
+    app.on('error', () => {
+    });
+    onerror(app, {
+      json: (err, ctx) => {
+        ctx.body = { error: err };
+      },
+    });
+    app.use(() => {
+      throw { code: 2, details: 'grpc upstream error' };
+    });
+
+    request(app.callback())
+      .get('/')
+      .set('Accept', 'application/json')
+      .expect(500)
+      .expect({ error: { code: 2, details: 'grpc upstream error', status: 500 } }, done);
+  });
+
   it('should wrap mock error obj instead of Error instance', done => {
     done = pedding(2, done);
     const app = new koa();


### PR DESCRIPTION
我们 BFF 项目基于 eggjs，BFF 调用 grpc 服务。如果 grpc 端抛出错误，会是一个 
```
{
code: 2,
details: 'xxx error'
```
的对象，没有 message 字段。这时报错就是： non-error thrown [object Object]，并且没有其他信息。

## 建议在 `onerror` 层，把 non-error object 所有字段拷贝，以便上层应用自行处理。

谢谢！