### PR TITLE
fix: stringify-err

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ module.exports = function onerror(app, options) {
       if (typeof err === 'object') {
         try {
           errMsg = JSON.stringify(err);
+          // eslint-disable-next-line no-empty
         } catch (e) {}
       }
       const newError = new Error('non-error thrown: ' + errMsg);

--- a/index.js
+++ b/index.js
@@ -36,7 +36,13 @@ module.exports = function onerror(app, options) {
 
     // wrap non-error object
     if (!(err instanceof Error)) {
-      const newError = new Error('non-error thrown: ' + err);
+      let errMsg = err;
+      if (typeof err === 'object') {
+        try {
+          errMsg = JSON.stringify(err);
+        } catch (e) {}
+      }
+      const newError = new Error('non-error thrown: ' + errMsg);
       // err maybe an object, try to copy the name, message and stack to the new error instance
       if (err) {
         if (err.name) newError.name = err.name;

--- a/test/json.test.js
+++ b/test/json.test.js
@@ -71,7 +71,7 @@ describe('json.test.js', () => {
       .expect({ error: 'Internal Server Error' }, done);
   });
 
-  it('should wrap non-error object', done => {
+  it('should wrap non-error primitive value', done => {
     const app = new koa();
     app.on('error', () => {});
     onerror(app);
@@ -84,6 +84,21 @@ describe('json.test.js', () => {
       .set('Accept', 'application/json')
       .expect(500)
       .expect({ error: 'non-error thrown: 1' }, done);
+  });
+
+  it('should wrap non-error object and stringify it', done => {
+    const app = new koa();
+    app.on('error', () => {});
+    onerror(app);
+    app.use(() => {
+      throw { error: true };
+    });
+
+    request(app.callback())
+      .get('/')
+      .set('Accept', 'application/json')
+      .expect(500)
+      .expect({ error: 'non-error thrown: {"error":true}' }, done);
   });
 
   it('should wrap mock error obj instead of Error instance', done => {


### PR DESCRIPTION
The `err` may be an object and the error message would print as `nodejs.Error: non-error thrown: [object Object]` which is not helpful, try to stringify it.