### PR TITLE
Use HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "koa error handler, hack ctx.onerror",
   "repository": {
     "type": "git",
-    "url": "git://github.com/koajs/onerror.git"
+    "url": "git+https://github.com/koajs/onerror.git"
   },
   "keywords": [
     "koa",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
     "typescript": "5",
     "urllib": "^4.6.11"
   },
+  "overrides": {
+    "fflate": "0.8.2"
+  },
   "scripts": {
     "lint": "eslint --cache src test --ext .ts",
     "pretest": "npm run clean && npm run lint -- --fix",

--- a/test/accepts.test.ts
+++ b/test/accepts.test.ts
@@ -68,7 +68,7 @@ describe('test/accepts.test.ts', () => {
       .set('Accept', '*/*')
       .expect('Content-Type', 'text/html; charset=utf-8')
       .expect('Location', 'http://foo.com/500.html')
-      .expect('Redirecting to <a href="http://foo.com/500.html">http://foo.com/500.html</a>.')
+      .expect('Redirecting to http://foo.com/500.html.')
       .expect(302);
   });
 });

--- a/test/multipart.test.ts
+++ b/test/multipart.test.ts
@@ -1,11 +1,17 @@
 import assert from 'node:assert';
+import { File } from 'node:buffer';
 import { scheduler } from 'node:timers/promises';
 import { Readable } from 'node:stream';
-import urllib from 'urllib';
 import formstream from 'formstream';
 import { mm } from 'mm';
 import { app } from './form_app.js';
 import { getFixtures } from './helper.js';
+
+if (typeof globalThis.File === 'undefined') {
+  (globalThis as any).File = File;
+}
+
+const { default: urllib } = await import('urllib');
 
 describe('test/multipart.test.ts', () => {
   let host: string;

--- a/test/redirect.test.ts
+++ b/test/redirect.test.ts
@@ -24,7 +24,7 @@ describe('test/redirect.test.ts', () => {
       .get('/')
       .set('Accept', 'text/html')
       .expect('Content-Type', 'text/html; charset=utf-8')
-      .expect('Redirecting to <a href="http://example/500.html">http://example/500.html</a>.')
+      .expect('Redirecting to http://example/500.html.')
       .expect('Location', 'http://example/500.html');
   });
 


### PR DESCRIPTION
## Summary
- update `package.json` repository.url from `git://` to `git+https://`
- refresh redirect response expectations for the current Koa 2 redirect body
- pin `fflate` to `0.8.2` via npm overrides so `attw --pack` completes reliably
- load `urllib` after providing the Node 18 `File` global used by its current `undici` dependency

## Validation
- `npm run ci` on Node 22.23.0
- `npm install --no-package-lock --no-fund && npm run ci` on Node 18.20.8
- node metadata assertion for `repository.url`, `bugs.url`, `homepage`, and the `fflate` override
- `git diff --check`
- `git ls-remote https://github.com/koajs/onerror.git HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  - Updated repository URL configuration and pinned a dependency version to improve stability.
* **Tests**
  - Adjusted redirect-related assertions to expect plain redirect text instead of HTML link formatting.
  - Updated multipart tests to handle environments without `globalThis.File` and improved `urllib` loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->